### PR TITLE
Public & modify |-setup|, offer PKViewImageStyleNone for PKViewImageStyle.

### DIFF
--- a/PaymentKit/PKView.h
+++ b/PaymentKit/PKView.h
@@ -17,14 +17,15 @@
 @class PKView, PKTextField;
 
 typedef enum {
-    PKViewStateCardNumber,
+  PKViewStateCardNumber,
 	PKViewStateExpiry,
 	PKViewStateCVC
 } PKViewState;
 
 typedef enum {
+  PKViewImageStyleNone,
 	PKViewImageStyleNormal,
-    PKViewImageStyleOutline
+  PKViewImageStyleOutline
 } PKViewImageStyle;
 
 @protocol PKViewDelegate <NSObject>
@@ -34,6 +35,8 @@ typedef enum {
 @end
 
 @interface PKView : UIView
+
+- (void)setup;
 
 - (BOOL)isValid;
 

--- a/PaymentKit/PKView.m
+++ b/PaymentKit/PKView.m
@@ -19,7 +19,6 @@
     BOOL isValidState;
 }
 
-- (void)setup;
 - (void)setupPlaceholderView;
 - (void)setupCardNumberField;
 - (void)setupCardExpiryField;
@@ -126,7 +125,9 @@
 
 - (void)setup
 {
-	self.imageStyle = PKViewImageStyleNormal;
+  if (self.imageStyle == PKViewImageStyleNone) {
+    self.imageStyle = PKViewImageStyleNormal;
+  }
 	self.borderStyle = UITextBorderStyleRoundedRect;
 	self.layer.masksToBounds = YES;
 	self.backgroundColor = [UIColor whiteColor];


### PR DESCRIPTION
So user can override `-setup` method and set `imageStyle` to `PKViewImageStyleOutline`, like below:

```
- (void)setup
{
  self.imageStyle = PKViewImageStyleOutline;

  [super setup];
}
```
