### PR TITLE
Convert PKCartType to NS_ENUM for Swift

### DIFF
--- a/PaymentKit/PKCardType.h
+++ b/PaymentKit/PKCardType.h
@@ -9,7 +9,7 @@
 #ifndef PKCardType_h
 #define PKCardType_h
 
-typedef enum {
+typedef NS_ENUM(NSInteger, PKCardType) {
     PKCardTypeVisa,
     PKCardTypeMasterCard,
     PKCardTypeAmex,
@@ -17,6 +17,6 @@ typedef enum {
     PKCardTypeJCB,
     PKCardTypeDinersClub,
     PKCardTypeUnknown
-} PKCardType;
+};
 
 #endif


### PR DESCRIPTION
I know hardly any object-c so treat with caution. But I successfully used this to access the PKCardType in swift.
